### PR TITLE
Only run luacov tests when TEST_COVERAGE = 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
   build:
     docker:
       - image: jloh/geojs-tests:beta-0.0.3
-    environment:
-      - TEST_COVERAGE: 1
     steps:
       - checkout
       - run:
@@ -33,8 +31,8 @@ jobs:
       - run:
           name: 'Test Coverage'
           command: |
-            luacov
-            luacov-coveralls
+            if [[ "${TEST_COVERAGE}x" == '1x' ]]; then luacov; fi
+            if [[ "${TEST_COVERAGE}x" == '1x' ]]; then luacov-coveralls; fi
       - store_artifacts:
           path: test_results.tgz
 


### PR DESCRIPTION
This prevent it from running when using CircleCI locally and spamming coveralls. The `TEST_COVERAGE` variable has also been moved to be set inside CircleCI.