### PR TITLE
Move Slack attachment title from pretext -> title

### DIFF
--- a/conf/v1/hooks.conf
+++ b/conf/v1/hooks.conf
@@ -256,11 +256,10 @@ location = /v1/hooks/slack {
                 response_type = slack_response_type,
                 attachments = {{
                     mrkdwn_in = {
-                        "text",
-                        "pretext"
+                        "text"
                     },
                     fallback    = "", -- TODO: Actually put something here good lord
-                    pretext     = title,
+                    title       = title,
                     text        = resp,
                     footer      = "Powered by <https://geojs.io|GeoJS>",
                     footer_icon = "https://static.jloh.co/geojs/avatar/hipchat/v1/geojs-icon_2x.png"


### PR DESCRIPTION
Closes #25

This follows the Slack style guide
https://api.slack.com/docs/message-guidelines