### PR TITLE
Add in support for GeoLite 2 DBs in tests

### DIFF
--- a/.circleci/Geoip.conf
+++ b/.circleci/Geoip.conf
@@ -1,0 +1,49 @@
+# Please see http://dev.maxmind.com/geoip/geoipupdate/ for instructions
+# on setting up geoipupdate, including information on how to download a
+# pre-filled GeoIP.conf file.
+
+# Enter your account ID and license key below. These are available from
+# https://www.maxmind.com/en/my_license_key. If you are only using free
+# GeoLite databases, you may leave the 0 values.
+AccountID 0
+LicenseKey 000000000000
+
+# Enter the edition IDs of the databases you would like to update.
+# Multiple edition IDs are separated by spaces.
+EditionIDs GeoLite2-City GeoLite2-ASN
+
+# The remaining settings are OPTIONAL.
+
+# The directory to store the database files. Defaults to /usr/local/share/GeoIP
+DatabaseDirectory /root/project/download-cache/maxmind2
+
+# The server to use. Defaults to "updates.maxmind.com".
+# Host updates.maxmind.com
+
+# The desired protocol either "https" (default) or "http".
+# Protocol https
+
+# The proxy host name or IP address. You may optionally specify a
+# port number, e.g., 127.0.0.1:8888. If no port number is specified, 1080
+# will be used.
+# Proxy 127.0.0.1:8888
+
+# The user name and password to use with your proxy server.
+# ProxyUserPassword username:password
+
+# Whether to skip host name verification on HTTPS connections.
+# Defaults to "0".
+# SkipHostnameVerification 0
+
+# Whether to skip peer verification on HTTPS connections.
+# Defaults to "0".
+# SkipPeerVerification 0
+
+# Whether to preserve modification times of files downloaded from the server.
+# Defaults to "0".
+# PreserveFileTimes 0
+
+# The lock file to use. This ensures only one geoipupdate process can run at a
+# time.
+# Defaults to ".geoipupdate.lock" under the DatabaseDirectory.
+# LockFile /usr/local/share/GeoIP/.geoipupdate.lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,29 @@ version: 2
 jobs:
   build:
     docker:
-      - image: jloh/geojs-tests:beta-0.0.3
+      - image: jloh/geojs-tests:beta-0.0.4
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - maxmind-geolite2-v1
       - run:
-          name: 'Download Maxmind DBs'
+          name: 'Download GeoLite1 Maxmind DBs'
           command: |
             mkdir -p download-cache/maxmind
             test -s download-cache/maxmind/GeoLiteCityv6.dat || curl -s http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz | gzip -dc > download-cache/maxmind/GeoLiteCityv6.dat
             test -s download-cache/maxmind/GeoIPv6.dat       || curl -s http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz                          | gzip -dc > download-cache/maxmind/GeoIPv6.dat
             test -s download-cache/maxmind/GeoIPASNumv6.dat  || curl -s http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz              | gzip -dc > download-cache/maxmind/GeoIPASNumv6.dat
+      - run:
+          name: 'Download GoeLite2 Maxmind DBs'
+          command: |
+            mkdir -p download-cache/maxmind2
+            cp .circleci/Geoip.conf /etc/GeoIP.conf
+            geoipupdate -v
+      - save_cache:
+          key: maxmind-geolite2-v1
+          paths:
+            - "download-cache/maxmind2"
       # Required repos
       # TODO: Work out a way to cache these?
       - run:

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get install -y lua-cjson nginx-extras cpanminus libluajit-5.1-dev libgd-dev git luarocks
+RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-add-repository ppa:maxmind/ppa
+RUN apt-get update && apt-get install -y lua-cjson nginx-extras cpanminus libluajit-5.1-dev libgd-dev git luarocks geoipupdate
 RUN cpanm -v --notest Test::Nginx TAP::Harness::Archive
 RUN luarocks install luacov-coveralls


### PR DESCRIPTION
Update docker image to have geoipupdate installed. We're using this to get the geolite2 DB images since its easier (the curl link goes to a tar archive which has a few things in it).

Caching still needs to be tested, pretty sure it wont _quite_ work how I'm intending at the moment. Raised a question on [their forum](https://discuss.circleci.com/t/caching-file-without-checksum/21371).