### PR TITLE
feat: add local test tooling with Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# MaxMind GeoLite2 credentials
+# Sign up for free at: https://www.maxmind.com/en/geolite2/signup
+MAXMIND_ACCOUNT_ID=your_account_id
+MAXMIND_LICENSE_KEY=your_license_key
+
+# MaxMind ASN Lua module URL (optional, for ASN lookups)
+MAXMIND_LUA_URL=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,20 @@ jobs:
           opm install xiaooloong/lua-resty-iconv=0.2.0
           opm install anjia0532/lua-resty-maxminddb=1.3.3
 
+      - name: Get current week number
+        id: week
+        run: echo "number=$(date +%Y-%W)" >> $GITHUB_OUTPUT
+
+      - name: Cache MaxMind GeoLite2 databases
+        id: cache-geoip
+        uses: actions/cache@v4
+        with:
+          path: /var/lib/GeoIP
+          # Cache key changes weekly (databases update Tues/Fri)
+          key: geoip-${{ steps.week.outputs.number }}-${{ hashFiles('.github/Geoip.conf') }}
+
       - name: Download MaxMind GeoLite2 databases
+        if: steps.cache-geoip.outputs.cache-hit != 'true'
         run: |
           cp .github/Geoip.conf /etc/GeoIP.conf
           echo "AccountID ${{ secrets.MAXMIND_ACCOUNT_ID }}" >> /etc/GeoIP.conf

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ download-cache/
 
 # Coverage reports
 luacov*
+
+# Environment files with secrets
+.env
+.env.local
+
+# MaxMind ASN module (downloaded during setup)
+lib/resty/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# GeoJS Test Environment
+# Replicates the CI environment for local testing
+FROM openresty/openresty:1.27.1.2-1-bullseye-fat
+
+# Install system dependencies
+# Note: We don't restrict to amd64 here to support ARM Macs
+RUN echo "deb http://deb.debian.org/debian bullseye contrib" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cpanminus \
+        libgd-dev \
+        libmaxminddb0 \
+        libmaxminddb-dev \
+        curl \
+        geoipupdate \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Perl test dependencies
+RUN cpanm -v --notest Test::Nginx TAP::Harness::Archive TAP::Formatter::JUnit
+
+# Install OPM packages
+RUN opm install ledgetech/lua-resty-http=0.16.1 && \
+    opm install openresty/lua-resty-dns=0.21 && \
+    opm install openresty/lua-resty-upload=0.10 && \
+    opm install bungle/lua-resty-reqargs=1.4 && \
+    opm install xiaooloong/lua-resty-iconv=0.2.0 && \
+    opm install anjia0532/lua-resty-maxminddb=1.3.3
+
+# Link OpenResty for Test::Nginx discovery
+RUN ln -sf /usr/local/openresty/bin/openresty /usr/bin/nginx
+
+# Create directories for MaxMind databases
+RUN mkdir -p /var/lib/GeoIP
+
+WORKDIR /opt/geojs
+
+# Default command runs all tests
+CMD ["prove", "-r", "t"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
   # Run tests
   tests:
     build: .
+    init: true
     working_dir: /opt/geojs
     volumes:
       - ./:/opt/geojs
@@ -46,6 +47,7 @@ services:
   # Interactive shell for debugging
   shell:
     build: .
+    init: true
     working_dir: /opt/geojs
     stdin_open: true
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,58 @@
+services:
+  # Download MaxMind GeoLite2 databases
+  # Requires MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY environment variables
+  setup:
+    build: .
+    volumes:
+      - ./:/opt/geojs
+      - geoip-data:/var/lib/GeoIP
+    environment:
+      - MAXMIND_ACCOUNT_ID
+      - MAXMIND_LICENSE_KEY
+      - MAXMIND_LUA_URL
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        set -e
+        if [ -z "$$MAXMIND_ACCOUNT_ID" ] || [ -z "$$MAXMIND_LICENSE_KEY" ]; then
+          echo "Error: MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY must be set"
+          echo "Get free credentials at: https://www.maxmind.com/en/geolite2/signup"
+          exit 1
+        fi
+        echo "Configuring geoipupdate..."
+        printf '%s\n' "EditionIDs GeoLite2-City GeoLite2-Country GeoLite2-ASN" "AccountID $$MAXMIND_ACCOUNT_ID" "LicenseKey $$MAXMIND_LICENSE_KEY" > /etc/GeoIP.conf
+        echo "Downloading MaxMind databases..."
+        geoipupdate -v
+        echo "Databases downloaded successfully to /var/lib/GeoIP"
+        ls -la /var/lib/GeoIP/
+        if [ -n "$$MAXMIND_LUA_URL" ]; then
+          echo "Downloading MaxMind ASN Lua module..."
+          mkdir -p /opt/geojs/lib/resty
+          curl -s -o /opt/geojs/lib/resty/maxminddb_asn.lua "$$MAXMIND_LUA_URL"
+        fi
+        echo "Setup complete!"
+
+  # Run tests
+  tests:
+    build: .
+    working_dir: /opt/geojs
+    volumes:
+      - ./:/opt/geojs
+      - geoip-data:/var/lib/GeoIP:ro
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+
+  # Interactive shell for debugging
+  shell:
+    build: .
+    working_dir: /opt/geojs
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./:/opt/geojs
+      - geoip-data:/var/lib/GeoIP:ro
+    entrypoint: ["/bin/bash"]
+
+volumes:
+  geoip-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,27 +10,8 @@ services:
       - MAXMIND_ACCOUNT_ID
       - MAXMIND_LICENSE_KEY
       - MAXMIND_LUA_URL
-    entrypoint: ["/bin/bash", "-c"]
-    command:
-      - |
-        set -e
-        if [ -z "$$MAXMIND_ACCOUNT_ID" ] || [ -z "$$MAXMIND_LICENSE_KEY" ]; then
-          echo "Error: MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY must be set"
-          echo "Get free credentials at: https://www.maxmind.com/en/geolite2/signup"
-          exit 1
-        fi
-        echo "Configuring geoipupdate..."
-        printf '%s\n' "EditionIDs GeoLite2-City GeoLite2-Country GeoLite2-ASN" "AccountID $$MAXMIND_ACCOUNT_ID" "LicenseKey $$MAXMIND_LICENSE_KEY" > /etc/GeoIP.conf
-        echo "Downloading MaxMind databases..."
-        geoipupdate -v
-        echo "Databases downloaded successfully to /var/lib/GeoIP"
-        ls -la /var/lib/GeoIP/
-        if [ -n "$$MAXMIND_LUA_URL" ]; then
-          echo "Downloading MaxMind ASN Lua module..."
-          mkdir -p /opt/geojs/lib/resty
-          curl -s -o /opt/geojs/lib/resty/maxminddb_asn.lua "$$MAXMIND_LUA_URL"
-        fi
-        echo "Setup complete!"
+    entrypoint: ["/bin/bash"]
+    command: ["/opt/geojs/scripts/setup.sh"]
 
   # Run tests
   tests:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,9 +15,6 @@ AccountID $MAXMIND_ACCOUNT_ID
 LicenseKey $MAXMIND_LICENSE_KEY
 EOF
 
-echo "Config file contents:"
-cat /etc/GeoIP.conf
-
 echo "Downloading MaxMind databases..."
 geoipupdate -v
 
@@ -27,7 +24,7 @@ ls -la /var/lib/GeoIP/
 if [ -n "$MAXMIND_LUA_URL" ]; then
     echo "Downloading MaxMind ASN Lua module..."
     mkdir -p /opt/geojs/lib/resty
-    curl -s -o /opt/geojs/lib/resty/maxminddb_asn.lua "$MAXMIND_LUA_URL"
+    curl -fsSL -o /opt/geojs/lib/resty/maxminddb_asn.lua "$MAXMIND_LUA_URL"
 fi
 
 echo "Setup complete!"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Download MaxMind GeoLite2 databases
+set -e
+
+if [ -z "$MAXMIND_ACCOUNT_ID" ] || [ -z "$MAXMIND_LICENSE_KEY" ]; then
+    echo "Error: MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY must be set"
+    echo "Get free credentials at: https://www.maxmind.com/en/geolite2/signup"
+    exit 1
+fi
+
+echo "Configuring geoipupdate..."
+cat > /etc/GeoIP.conf << EOF
+EditionIDs GeoLite2-City GeoLite2-Country GeoLite2-ASN
+AccountID $MAXMIND_ACCOUNT_ID
+LicenseKey $MAXMIND_LICENSE_KEY
+EOF
+
+echo "Config file contents:"
+cat /etc/GeoIP.conf
+
+echo "Downloading MaxMind databases..."
+geoipupdate -v
+
+echo "Databases downloaded successfully to /var/lib/GeoIP"
+ls -la /var/lib/GeoIP/
+
+if [ -n "$MAXMIND_LUA_URL" ]; then
+    echo "Downloading MaxMind ASN Lua module..."
+    mkdir -p /opt/geojs/lib/resty
+    curl -s -o /opt/geojs/lib/resty/maxminddb_asn.lua "$MAXMIND_LUA_URL"
+fi
+
+echo "Setup complete!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Run GeoJS tests locally using Docker
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# Check for .env file
+if [ ! -f .env ]; then
+    if [ -z "$MAXMIND_ACCOUNT_ID" ] || [ -z "$MAXMIND_LICENSE_KEY" ]; then
+        echo "Error: MaxMind credentials not found."
+        echo ""
+        echo "Either create a .env file from .env.example:"
+        echo "  cp .env.example .env"
+        echo "  # Then edit .env with your credentials"
+        echo ""
+        echo "Or set environment variables:"
+        echo "  export MAXMIND_ACCOUNT_ID=your_account_id"
+        echo "  export MAXMIND_LICENSE_KEY=your_license_key"
+        echo ""
+        echo "Get free credentials at: https://www.maxmind.com/en/geolite2/signup"
+        exit 1
+    fi
+else
+    # Load .env file
+    set -a
+    source .env
+    set +a
+fi
+
+# Check if setup has been run (volume has data)
+if ! docker volume inspect geojs_geoip-data >/dev/null 2>&1; then
+    echo "Running first-time setup (downloading MaxMind databases)..."
+    docker compose run --rm setup
+fi
+
+# Run tests
+echo "Running tests..."
+docker compose run --rm tests "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,12 +30,12 @@ else
     set +a
 fi
 
-# Check if setup has been run (volume has data)
-if ! docker volume inspect geojs_geoip-data >/dev/null 2>&1; then
+# Check if setup has been run (volume exists regardless of project name prefix)
+if ! docker volume ls -q --filter name=geoip-data | grep -q geoip-data; then
     echo "Running first-time setup (downloading MaxMind databases)..."
     docker compose run --rm setup
 fi
 
 # Run tests
 echo "Running tests..."
-docker compose run --rm tests "$@"
+docker compose run --rm tests prove -r t "$@"


### PR DESCRIPTION
## Summary

- Add Docker-based local development environment that replicates the GitHub Actions CI setup
- Dockerfile builds an OpenResty image with all required dependencies (Perl test modules, OPM packages, system libraries)
- docker-compose.yaml provides three services:
  - `setup` - Downloads MaxMind GeoLite2 databases and ASN Lua module
  - `tests` - Runs the test suite via `prove -r t`
  - `shell` - Interactive debugging shell

## Usage

1. Copy `.env.example` to `.env` and add your MaxMind credentials
2. Run `./scripts/test.sh` or `docker compose run tests`

## Test plan

- [x] Verify Docker image builds successfully
- [x] Verify MaxMind database download works with valid credentials
- [ ] Verify `docker compose run tests` runs the test suite
- [x] Verify tests pass locally as they do in CI