### PR TITLE
chore(deps): bump opm packages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,3 @@
 # Sign up for free at: https://www.maxmind.com/en/geolite2/signup
 MAXMIND_ACCOUNT_ID=your_account_id
 MAXMIND_LICENSE_KEY=your_license_key
-
-# MaxMind ASN Lua module URL (optional, for ASN lookups)
-MAXMIND_LUA_URL=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
 
       - name: Install OPM packages
         run: |
-          opm install ledgetech/lua-resty-http=0.16.1
-          opm install openresty/lua-resty-dns=0.21
+          opm install ledgetech/lua-resty-http=0.17.1
+          opm install openresty/lua-resty-dns=0.23
           opm install openresty/lua-resty-upload=0.10
           opm install bungle/lua-resty-reqargs=1.4
           opm install xiaooloong/lua-resty-iconv=0.2.0
-          opm install anjia0532/lua-resty-maxminddb=1.3.3
+          opm install anjia0532/lua-resty-maxminddb=1.3.7
 
       - name: Get current week number
         id: week
@@ -55,11 +55,6 @@ jobs:
           echo "LicenseKey ${{ secrets.MAXMIND_TOKEN }}" >> /etc/GeoIP.conf
           geoipupdate -v
           rm /etc/GeoIP.conf
-
-      - name: Download MaxMind ASN Lua module
-        run: |
-          mkdir -p lib/resty
-          curl -s -o lib/resty/maxminddb_asn.lua "${{ secrets.MAXMIND_LUA_URL }}"
 
       - name: OpenResty version
         run: openresty -V

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ RUN echo "deb http://deb.debian.org/debian bullseye contrib" >> /etc/apt/sources
 RUN cpanm -v --notest Test::Nginx TAP::Harness::Archive TAP::Formatter::JUnit
 
 # Install OPM packages
-RUN opm install ledgetech/lua-resty-http=0.16.1 && \
-    opm install openresty/lua-resty-dns=0.21 && \
+RUN opm install ledgetech/lua-resty-http=0.17.1 && \
+    opm install openresty/lua-resty-dns=0.23 && \
     opm install openresty/lua-resty-upload=0.10 && \
     opm install bungle/lua-resty-reqargs=1.4 && \
     opm install xiaooloong/lua-resty-iconv=0.2.0 && \
-    opm install anjia0532/lua-resty-maxminddb=1.3.3
+    opm install anjia0532/lua-resty-maxminddb=1.3.7
 
 # Link OpenResty for Test::Nginx discovery
 RUN ln -sf /usr/local/openresty/bin/openresty /usr/bin/nginx

--- a/conf/v1/init.conf
+++ b/conf/v1/init.conf
@@ -1,14 +1,11 @@
 init_by_lua_block {
-    local geo     = require('resty.maxminddb')
-    local geo_asn = require('resty.maxminddb_asn')
+    local geo = require('resty.maxminddb')
 
-    -- Init our DBs if they haven't been
     if not geo.initted() then
-        geo.init("/var/lib/GeoIP/GeoLite2-City.mmdb")
-    end
-
-    if not geo_asn.initted() then
-        geo_asn.init("/var/lib/GeoIP/GeoLite2-ASN.mmdb")
+        geo.init({
+            city = "/var/lib/GeoIP/GeoLite2-City.mmdb",
+            asn  = "/var/lib/GeoIP/GeoLite2-ASN.mmdb",
+        })
     end
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     environment:
       - MAXMIND_ACCOUNT_ID
       - MAXMIND_LICENSE_KEY
-      - MAXMIND_LUA_URL
     entrypoint: ["/bin/bash"]
     command: ["/opt/geojs/scripts/setup.sh"]
 

--- a/lib/geojs/utils.lua
+++ b/lib/geojs/utils.lua
@@ -270,22 +270,20 @@ local function sorted_encode(data)
 end
 _M.sorted_encode = sorted_encode
 
--- Maxmind DB implemntation
+-- Maxmind DB implementation
 local function geoip_lookup(ip)
-	local geo     = require('resty.maxminddb')
-	local geo_asn = require('resty.maxminddb_asn')
+	local geo = require('resty.maxminddb')
 	-- Init our DBs if they haven't been
 	if not geo.initted() then
-		geo.init("/var/lib/GeoIP/GeoLite2-City.mmdb")
-	end
-
-	if not geo_asn.initted() then
-		geo_asn.init("/var/lib/GeoIP/GeoLite2-ASN.mmdb")
+		geo.init({
+			city = "/var/lib/GeoIP/GeoLite2-City.mmdb",
+			asn  = "/var/lib/GeoIP/GeoLite2-ASN.mmdb",
+		})
 	end
 
 	-- Lookup Geo data
-	local ip_geo, ip_geo_err = geo.lookup(ip)
-	local ip_asn, ip_asn_err = geo_asn.lookup(ip)
+	local ip_geo, ip_geo_err = geo.lookup(ip, nil, "city")
+	local ip_asn, ip_asn_err = geo.lookup(ip, nil, "asn")
 	if ip_geo_err then
 		ngx_log(log_level.ERR, "Error with Geo DB: ", ip_geo_err)
 	end

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,10 +21,4 @@ geoipupdate -v
 echo "Databases downloaded successfully to /var/lib/GeoIP"
 ls -la /var/lib/GeoIP/
 
-if [ -n "$MAXMIND_LUA_URL" ]; then
-    echo "Downloading MaxMind ASN Lua module..."
-    mkdir -p /opt/geojs/lib/resty
-    curl -fsSL -o /opt/geojs/lib/resty/maxminddb_asn.lua "$MAXMIND_LUA_URL"
-fi
-
 echo "Setup complete!"


### PR DESCRIPTION
no ref

- The newer version of the `lua-resty-maxminddb` package lets us init all our DBs at the same time which means we no longer need to bundle our own patched version