### PR TITLE
feat: add Cloudflare CDN edge caching for cacheable endpoints

### DIFF
--- a/conf/v1/dns.conf
+++ b/conf/v1/dns.conf
@@ -1,18 +1,19 @@
 location = /v1/dns/ptr {
     default_type text/plain;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr = require("geojs.utils").get_ptr
+        local utils = require("geojs.utils")
         -- Vars
         local record
         -- Get the IP we want
         local args = ngx.req.get_uri_args()
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             record = args.ip
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             record = ngx.var.remote_addr
         end
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
         ngx.say(ptr)
     }
 }
@@ -20,41 +21,37 @@ location = /v1/dns/ptr {
 location ~ "/v1/dns/ptr/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))$" {
     default_type text/plain;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr   = require("geojs.utils").get_ptr
+        local utils    = require("geojs.utils")
         local ngx_vars = ngx.var
-
-        -- Vars
-        local record
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Get the IP we want
-        record = ngx_vars.ip
+        local record = ngx_vars.ip
 
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
         ngx.say(ptr)
-
     }
 }
 
 location = /v1/dns/ptr.json {
     default_type application/json;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr      = require("geojs.utils").get_ptr
-        local json_encode = require("geojs.utils").sorted_encode
+        local utils = require("geojs.utils")
 
         -- Vars!
         local record
         -- Get the IP we want
         local args = ngx.req.get_uri_args()
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             record = args.ip
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             record = ngx.var.remote_addr
         end
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
         ngx.say(
-            json_encode({
+            utils.sorted_encode({
                 ["ptr"] = ptr
             })
         )
@@ -64,21 +61,17 @@ location = /v1/dns/ptr.json {
 location ~ "/v1/dns/ptr/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.json$" {
     default_type application/json;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr      = require("geojs.utils").get_ptr
-        local ngx_vars    = ngx.var
-        local json_encode = require("geojs.utils").sorted_encode
-
-        -- Vars!
-        local record
+        local utils    = require("geojs.utils")
+        local ngx_vars = ngx.var
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Get the IP we want
-        record = ngx_vars.ip
+        local record = ngx_vars.ip
 
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
 
         ngx.say(
-            json_encode({
+            utils.sorted_encode({
                 ["ptr"] = ptr
             })
         )
@@ -88,10 +81,7 @@ location ~ "/v1/dns/ptr/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-
 location = /v1/dns/ptr.js {
     default_type application/javascript;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr       = require("geojs.utils").get_ptr
-        local get_callback = require("geojs.utils").generate_callback
-        local json_encode  = require("geojs.utils").sorted_encode
+        local utils = require("geojs.utils")
 
         -- Vars!
         local record, callback
@@ -99,19 +89,21 @@ location = /v1/dns/ptr.js {
         -- Get the IP we want
         local args = ngx.req.get_uri_args()
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             record = args.ip
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             record = ngx.var.remote_addr
         end
 
         -- Override our callback if it exists
-        callback = get_callback('ptr', args)
+        callback = utils.generate_callback('ptr', args)
 
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
         ngx.say(
             callback,
             '(',
-            json_encode({
+            utils.sorted_encode({
                 ["ptr"] = ptr
             }),
             ')'
@@ -122,28 +114,22 @@ location = /v1/dns/ptr.js {
 location ~ "/v1/dns/ptr/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.js$" {
     default_type application/javascript;
     content_by_lua_block {
-        -- Function to get our PTR!
-        local getptr       = require("geojs.utils").get_ptr
-        local get_callback = require("geojs.utils").generate_callback
-        local ngx_vars     = ngx.var
-        local args         = ngx.req.get_uri_args()
-        local json_encode  = require("geojs.utils").sorted_encode
-
-        -- Vars!
-        local record
-        local callback
+        local utils    = require("geojs.utils")
+        local ngx_vars = ngx.var
+        local args     = ngx.req.get_uri_args()
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Get the IP we want
-        record = ngx_vars.ip
+        local record = ngx_vars.ip
 
         -- Override our callback if it exists
-        callback = get_callback('ptr', args)
+        local callback = utils.generate_callback('ptr', args)
 
-        local ptr = getptr(record)
+        local ptr = utils.get_ptr(record)
         ngx.say(
             callback,
             '(',
-            json_encode({
+            utils.sorted_encode({
                 ["ptr"] = ptr
             }),
             ')'

--- a/conf/v1/ip.conf
+++ b/conf/v1/ip.conf
@@ -1,6 +1,8 @@
 location = /v1/ip {
     default_type text/plain;
     content_by_lua_block {
+        local set_cache_headers = require("geojs.utils").set_cache_headers
+        set_cache_headers(false) -- Not cacheable: uses requester's IP
         ngx.say(ngx.var.remote_addr)
     }
 }
@@ -8,21 +10,22 @@ location = /v1/ip {
 location = /v1/ip.json {
     default_type application/json;
     content_by_lua_block {
-        local json_encode = require("geojs.utils").sorted_encode
-        ngx.say(json_encode({ip = ngx.var.remote_addr}))
+        local utils = require("geojs.utils")
+        utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
+        ngx.say(utils.sorted_encode({ip = ngx.var.remote_addr}))
     }
 }
 
 location = /v1/ip.js {
     default_type application/javascript;
     content_by_lua_block {
-        local get_callback = require("geojs.utils").generate_callback
-        local json_encode  = require("geojs.utils").sorted_encode
+        local utils = require("geojs.utils")
+        utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
         -- Get callback
         local args = ngx.req.get_uri_args()
-        local callback = get_callback('geoip', args)
+        local callback = utils.generate_callback('geoip', args)
 
-        ngx.say(callback, '(', json_encode({ip = ngx.var.remote_addr}), ')')
+        ngx.say(callback, '(', utils.sorted_encode({ip = ngx.var.remote_addr}), ')')
     }
 }
 
@@ -30,24 +33,25 @@ location = /v1/ip/country {
     default_type text/plain;
     content_by_lua_block {
         local args   = ngx.req.get_uri_args()
-        local split  = require("geojs.utils").split
-        local lookup = require("geojs.utils").country_lookup
+        local utils  = require("geojs.utils")
 
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = ""
             local info = ""
             --- Put our IPs into a table
-            ips = split(args.ip, ',')
+            ips = utils.split(args.ip, ',')
             for k,v in ipairs(ips) do
                 -- Get our info from upstream
-                info = lookup(v)
+                info = utils.country_lookup(v)
                 -- Add our new info to our msg
                 msg = msg .. v .. ': ' .. info["country"] .. '\n'
             end
             ngx.print(msg)
         else
-            local info = lookup(ngx.var.remote_addr)
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
+            local info = utils.country_lookup(ngx.var.remote_addr)
             ngx.say(info["country"])
         end
     }
@@ -57,9 +61,10 @@ location ~ "/v1/ip/country/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-
     default_type text/plain;
     content_by_lua_block {
         local ngx_var = ngx.var
-        local lookup  = require("geojs.utils").country_lookup
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
-        local info = lookup(ngx_var.ip)
+        local info = utils.country_lookup(ngx_var.ip)
         ngx.say(info["country"])
     }
 }
@@ -68,24 +73,25 @@ location = /v1/ip/country/full {
     default_type text/plain;
     content_by_lua_block {
         local args   = ngx.req.get_uri_args()
-        local split  = require("geojs.utils").split
-        local lookup = require("geojs.utils").country_lookup
+        local utils  = require("geojs.utils")
 
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = ""
             local info = ""
             --- Put our IPs into a table
-            ips = split(args.ip, ',')
+            ips = utils.split(args.ip, ',')
             for k,v in ipairs(ips) do
                 -- Get our info from upstream
-                info = lookup(v)
+                info = utils.country_lookup(v)
                 -- Add our new info to our msg
                 msg = msg .. v .. ': ' .. info["name"] .. '\n'
             end
             ngx.print(msg)
         else
-            local info = lookup(ngx.var.remote_addr)
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
+            local info = utils.country_lookup(ngx.var.remote_addr)
             ngx.say(info["name"])
         end
     }
@@ -95,9 +101,10 @@ location ~ "/v1/ip/country/full/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}
     default_type text/plain;
     content_by_lua_block {
         local ngx_var = ngx.var
-        local lookup  = require("geojs.utils").country_lookup
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
-        local info = lookup(ngx_var.ip)
+        local info = utils.country_lookup(ngx_var.ip)
         ngx.say(info["name"])
     }
 }
@@ -105,30 +112,30 @@ location ~ "/v1/ip/country/full/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}
 location = /v1/ip/country.json {
     default_type application/json;
     content_by_lua_block {
-        local args        = ngx.req.get_uri_args()
-        local ngx_var     = ngx.var
-        local split       = require("geojs.utils").split
-        local lookup      = require("geojs.utils").country_lookup
-        local json_encode = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
 
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = {}
             local info = ""
             -- Put our IPs into a table
-            ips = split(args.ip, ',')
+            ips = utils.split(args.ip, ',')
             -- Get our info for each IP
             for k,v in ipairs(ips) do
                 -- Get our info form upstream
-                info = lookup(v)
+                info = utils.country_lookup(v)
                 -- Add our new info to our msg table
                 table.insert(msg, info)
             end
-            ngx.say(json_encode(msg))
+            ngx.say(utils.sorted_encode(msg))
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             -- Set our req IP
-            local info = lookup(ngx_var.remote_addr)
-            ngx.say(json_encode(info))
+            local info = utils.country_lookup(ngx_var.remote_addr)
+            ngx.say(utils.sorted_encode(info))
         end
     }
 }
@@ -136,57 +143,56 @@ location = /v1/ip/country.json {
 location ~ "/v1/ip/country/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.json$" {
     default_type application/json;
     content_by_lua_block {
-        local ngx_var     = ngx.var
-        local lookup      = require("geojs.utils").country_lookup
-        local json_encode = require("geojs.utils").sorted_encode
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Set our req IP
-        local info = lookup(ngx_var.ip)
-        ngx.say(json_encode(info))
+        local info = utils.country_lookup(ngx_var.ip)
+        ngx.say(utils.sorted_encode(info))
     }
 }
 
 location = /v1/ip/country.js {
     default_type application/javascript;
     content_by_lua_block {
-        local args         = ngx.req.get_uri_args()
-        local ngx_var      = ngx.var
-        local split        = require("geojs.utils").split
-        local get_callback = require("geojs.utils").generate_callback
-        local lookup       = require("geojs.utils").country_lookup
-        local json_encode  = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
 
         -- Get our custom callback is it exists
-        local callback = get_callback('countryip', args)
+        local callback = utils.generate_callback('countryip', args)
 
         -- If we have IP args, lets use those
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = {}
             local info = ""
             -- Put our IPs into a table
-            ips = split(args.ip, ",")
+            ips = utils.split(args.ip, ",")
             -- Get our info for each IP
             for k,v in ipairs(ips) do
                 -- Get our info from upstream
-                info = lookup(v)
+                info = utils.country_lookup(v)
                 -- Add our new info to our msg table
                 table.insert(msg, info)
             end
             ngx.say(
                 callback,
                 "(",
-                json_encode(msg),
+                utils.sorted_encode(msg),
                 ")"
             )
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             -- Since we don't have an IP arg we're assuming we've just got a single IP
             local req_ip = ngx.var.remote_addr
-            local info   = lookup(req_ip)
+            local info   = utils.country_lookup(req_ip)
             ngx.say(
                 callback,
                 '(',
-                json_encode(info),
+                utils.sorted_encode(info),
                 ')'
             )
         end
@@ -196,20 +202,19 @@ location = /v1/ip/country.js {
 location ~ "/v1/ip/country/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.js$" {
     default_type application/javascript;
     content_by_lua_block {
-        local args         = ngx.req.get_uri_args()
-        local ngx_var      = ngx.var
-        local get_callback = require("geojs.utils").generate_callback
-        local lookup       = require("geojs.utils").country_lookup
-        local json_encode  = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Get our custom callback is it exists
-        local callback = get_callback('countryip', args)
+        local callback = utils.generate_callback('countryip', args)
 
-        local info = lookup(ngx_var.ip)
+        local info = utils.country_lookup(ngx_var.ip)
         ngx.say(
             callback,
             '(',
-            json_encode(info),
+            utils.sorted_encode(info),
             ')'
         )
     }
@@ -218,31 +223,31 @@ location ~ "/v1/ip/country/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-
 location = /v1/ip/geo.json {
     default_type application/json;
     content_by_lua_block {
-        local args        = ngx.req.get_uri_args()
-        local ngx_var     = ngx.var
-        local split       = require("geojs.utils").split
-        local lookup      = require("geojs.utils").geo_lookup
-        local json_encode = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
 
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = {}
             local info = ""
             -- Put our IPs into a table
-            ips = split(args.ip, ',')
+            ips = utils.split(args.ip, ',')
             -- Get our info for each IP
             for k,v in ipairs(ips) do
                 -- Get our info form upstream
-                info = lookup(v)
+                info = utils.geo_lookup(v)
                 -- Add our new info to our msg table
                 table.insert(msg, info)
             end
-            ngx.say(json_encode(msg))
+            ngx.say(utils.sorted_encode(msg))
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             -- Set our req IP
             local req_ip = ngx.var.remote_addr
-            local info   = lookup(req_ip)
-            ngx.say(json_encode(info))
+            local info   = utils.geo_lookup(req_ip)
+            ngx.say(utils.sorted_encode(info))
         end
     }
 }
@@ -250,39 +255,37 @@ location = /v1/ip/geo.json {
 location ~ "/v1/ip/geo/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.json$" {
     default_type application/json;
     content_by_lua_block {
-        local ngx_var     = ngx.var
-        local lookup      = require("geojs.utils").geo_lookup
-        local json_encode = require("geojs.utils").sorted_encode
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Set our req IP
-        local info = lookup(ngx_var.ip)
-        ngx.say(json_encode(info))
+        local info = utils.geo_lookup(ngx_var.ip)
+        ngx.say(utils.sorted_encode(info))
     }
 }
 
 location = /v1/ip/geo.js {
     default_type application/javascript;
     content_by_lua_block {
-        local args         = ngx.req.get_uri_args()
-        local ngx_var      = ngx.var
-        local split        = require("geojs.utils").split
-        local lookup       = require("geojs.utils").geo_lookup
-        local get_callback = require("geojs.utils").generate_callback
-        local json_encode  = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
 
         -- Get our custom callback if we've got one
-        local callback = get_callback('geoip', args)
+        local callback = utils.generate_callback('geoip', args)
 
         -- If we have IPs in args loop through them
         if args.ip then
+            utils.set_cache_headers(true) -- Cacheable: explicit IP in query
             local ips  = {}
             local msg  = {}
             local info = ""
             -- Put our IPs into a table
-            ips = split(args.ip, ",")
+            ips = utils.split(args.ip, ",")
             -- Get our info for each IP
             for k,v in ipairs(ips) do
-                info = lookup(v)
+                info = utils.geo_lookup(v)
                 -- Add our new info to our msg table
                 table.insert(msg, info)
             end
@@ -290,17 +293,18 @@ location = /v1/ip/geo.js {
             ngx.say(
                 callback,
                 "(",
-                json_encode(msg),
+                utils.sorted_encode(msg),
                 ")"
             )
         else
+            utils.set_cache_headers(false) -- Not cacheable: uses requester's IP
             -- Since we don't have an IP arg we're assuming we've just got a single IP
             local req_ip = ngx.var.remote_addr
-            local info   = lookup(req_ip)
+            local info   = utils.geo_lookup(req_ip)
             ngx.say(
                 callback,
                 '(',
-                json_encode(info),
+                utils.sorted_encode(info),
                 ')'
             )
         end
@@ -310,20 +314,19 @@ location = /v1/ip/geo.js {
 location ~ "/v1/ip/geo/(?<ip>((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])))\.js$" {
     default_type application/javascript;
     content_by_lua_block {
-        local args         = ngx.req.get_uri_args()
-        local ngx_var      = ngx.var
-        local lookup       = require("geojs.utils").geo_lookup
-        local get_callback = require("geojs.utils").generate_callback
-        local json_encode  = require("geojs.utils").sorted_encode
+        local args    = ngx.req.get_uri_args()
+        local ngx_var = ngx.var
+        local utils   = require("geojs.utils")
+        utils.set_cache_headers(true) -- Cacheable: explicit IP in path
 
         -- Get our custom callback if we've got one
-        local callback = get_callback('geoip', args)
+        local callback = utils.generate_callback('geoip', args)
 
-        local info = lookup(ngx_var.ip)
+        local info = utils.geo_lookup(ngx_var.ip)
         ngx.say(
             callback,
             '(',
-            json_encode(info),
+            utils.sorted_encode(info),
             ')'
         )
     }

--- a/lib/geojs/utils.lua
+++ b/lib/geojs/utils.lua
@@ -20,6 +20,23 @@ local _M                 = {
 	_VERSION = "0.0.2"
 }
 
+-- Cache control headers for Cloudflare CDN
+-- When is_cacheable is true: cache at Cloudflare edge for 1 year (can be purged)
+-- When is_cacheable is false: tell Cloudflare not to cache
+-- In both cases, browsers/downstream caches are told not to cache
+local CACHE_TTL = 31536000 -- 1 year in seconds
+
+function _M.set_cache_headers(is_cacheable)
+	-- Always tell browsers not to cache (data may be stale after purge)
+	ngx.header["Cache-Control"] = "private, no-store"
+	-- Tell Cloudflare edge whether to cache
+	if is_cacheable then
+		ngx.header["Cloudflare-CDN-Cache-Control"] = "max-age=" .. CACHE_TTL
+	else
+		ngx.header["Cloudflare-CDN-Cache-Control"] = "private"
+	end
+end
+
 local default_geo_lookup = {
 	["city"] = {
 		["names"] = {}

--- a/t/v1/ip/06-caching.t
+++ b/t/v1/ip/06-caching.t
@@ -1,0 +1,314 @@
+use Test::Nginx::Socket 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+
+$ENV{TEST_COVERAGE} ||= 0;
+
+our $HttpConfig = qq{
+    init_by_lua_block {
+        if $ENV{TEST_COVERAGE} == 1 then
+            require("luacov.runner").init()
+        end
+    }
+    lua_package_path "$pwd/lib/?.lua;;";
+    real_ip_header X-IP;
+    set_real_ip_from  127.0.0.1/32;
+};
+
+no_long_string();
+no_diff();
+run_tests();
+
+__DATA__
+=== TEST 1: /v1/ip should NOT be cacheable (uses requester IP)
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 2: /v1/ip.json should NOT be cacheable (uses requester IP)
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip.json
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 3: /v1/ip.js should NOT be cacheable (uses requester IP)
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip.js
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 4: /v1/ip/country (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 5: /v1/ip/country/{IP} should BE cacheable (explicit IP in path)
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country/8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 6: /v1/ip/country?ip=X should BE cacheable (explicit IP in query)
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 7: /v1/ip/country.json (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country.json
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 8: /v1/ip/country/{IP}.json should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country/8.8.8.8.json
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 9: /v1/ip/country.json?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country.json?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 10: /v1/ip/country.js (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country.js
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 11: /v1/ip/country/{IP}.js should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country/8.8.8.8.js
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 12: /v1/ip/country.js?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country.js?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 13: /v1/ip/country/full (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country/full
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 14: /v1/ip/country/full/{IP} should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/country/full/8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 15: /v1/ip/geo.json (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo.json
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 16: /v1/ip/geo/{IP}.json should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo/8.8.8.8.json
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 17: /v1/ip/geo.json?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo.json?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 18: /v1/ip/geo.js (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo.js
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 19: /v1/ip/geo/{IP}.js should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo/8.8.8.8.js
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 20: /v1/ip/geo.js?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/ip.conf";
+--- request
+GET /v1/ip/geo.js?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+

--- a/t/v1/ip/07-dns-caching.t
+++ b/t/v1/ip/07-dns-caching.t
@@ -1,0 +1,163 @@
+use Test::Nginx::Socket 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+
+$ENV{TEST_COVERAGE} ||= 0;
+
+our $HttpConfig = qq{
+    init_by_lua_block {
+        if $ENV{TEST_COVERAGE} == 1 then
+            require("luacov.runner").init()
+        end
+    }
+    lua_package_path "$pwd/lib/?.lua;;";
+    real_ip_header X-IP;
+    set_real_ip_from  127.0.0.1/32;
+};
+
+no_long_string();
+no_diff();
+run_tests();
+
+__DATA__
+=== TEST 1: /v1/dns/ptr (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 2: /v1/dns/ptr/{IP} should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr/8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 3: /v1/dns/ptr?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 4: /v1/dns/ptr.json (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr.json
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 5: /v1/dns/ptr/{IP}.json should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr/8.8.8.8.json
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 6: /v1/dns/ptr.json?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr.json?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 7: /v1/dns/ptr.js (no IP param) should NOT be cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr.js
+--- more_headers
+X-IP: 8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: private
+
+
+=== TEST 8: /v1/dns/ptr/{IP}.js should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr/8.8.8.8.js
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+
+
+=== TEST 9: /v1/dns/ptr.js?ip=X should BE cacheable
+--- http_config eval
+"$::HttpConfig"
+--- config
+    include "../../../conf/v1/dns.conf";
+    set $geojs_dns_server '8.8.8.8';
+--- request
+GET /v1/dns/ptr.js?ip=8.8.8.8
+--- no_error_log
+[error]
+--- response_headers
+Cache-Control: private, no-store
+Cloudflare-CDN-Cache-Control: max-age=31536000
+


### PR DESCRIPTION
## Summary

- Add cache control headers using `Cloudflare-CDN-Cache-Control` to instruct Cloudflare CDN to cache responses at the edge for up to 1 year
- Ensures only endpoints with explicit IP lookups are cached (deterministic responses)
- Endpoints using the requester's IP remain non-cacheable (dynamic responses)
- Browsers always receive `Cache-Control: private, no-store` to prevent stale data after cache purges

### Cacheable endpoints (edge TTL: 1 year)
These endpoints have deterministic responses based on the explicit IP:
- Path-based: `/v1/ip/country/{IP}`, `/v1/ip/geo/{IP}.json`, `/v1/dns/ptr/{IP}`, etc.
- Query-based: Any endpoint with `?ip=` parameter

### Non-cacheable endpoints
These return data specific to the requester's IP:
- `/v1/ip`, `/v1/ip.json`, `/v1/ip.js` (returns requester's IP)
- `/v1/ip/country`, `/v1/ip/geo.json`, etc. without IP parameter

## Implementation

Added a `set_cache_headers(is_cacheable)` utility function that sets:
- `Cache-Control: private, no-store` (browsers never cache)
- `Cloudflare-CDN-Cache-Control: max-age=31536000` (cacheable) or `private` (non-cacheable)

## Test plan

- [x] Added 20 tests for IP/country/geo caching behavior (t/v1/ip/06-caching.t)
- [x] Added 9 tests for DNS PTR caching behavior (t/v1/ip/07-dns-caching.t)
- [x] All 355 existing + new tests pass
- [x] Verified cacheable endpoints return `Cloudflare-CDN-Cache-Control: max-age=31536000`
- [x] Verified non-cacheable endpoints return `Cloudflare-CDN-Cache-Control: private`